### PR TITLE
error: Unknown socket type inherit-wayland-socket

### DIFF
--- a/org.fcitx.Fcitx5.yaml
+++ b/org.fcitx.Fcitx5.yaml
@@ -20,7 +20,7 @@ finish-args:
   - --socket=x11
   - --share=ipc
   - --socket=wayland
-  - --socket=inherit-wayland-socket
+  - --socket=fallback-x11
   - --share=network
   - --filesystem=xdg-config/kxkbrc:rw
   - --filesystem=xdg-config/fontconfig:ro


### PR DESCRIPTION
 inherit-wayland-socket -> fallback-x11

```
error: Unknown socket type inherit-wayland-socket, valid types are: x11, wayland, pulseaudio, session-bus, system-bus, fallback-x11, ssh-auth, pcsc, cups, gpg-agent
```