### PR TITLE
Use the flatpak version of bazel.(update_mozc_deps)

### DIFF
--- a/update_mozc_deps
+++ b/update_mozc_deps
@@ -15,12 +15,12 @@ set -e
 
 rm -rf $HOME/.cache/bazel
 
-_MOZC_BAZEL_CACHE=/tmp/mozc_cache
+_MOZC_BAZEL_CACHE=$TMPDIR/mozc_cache
 
 rm -rf $_MOZC_BAZEL_CACHE
 for target in unix/fcitx5:fcitx5-mozc.so server:mozc_server gui/tool:mozc_tool; do
     # Only cquery accepts --config and it can also trigger the cache update
-    bazel cquery --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux $target
+    flatpak run --share=network --filesystem=host --runtime=org.kde.Sdk//6.6 --command=sh --env=PKG_CONFIG_PATH=/app/lib/pkgconfig org.fcitx.Fcitx5 -c "/usr/lib/sdk/bazel/bin/bazel cquery --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux $target"
 done
 
 pushd .

--- a/update_mozc_deps
+++ b/update_mozc_deps
@@ -3,11 +3,11 @@
 BASE=$PWD
 pushd .
 if [ ! -d mozc ]; then
-    git clone https://github.com/fcitx/mozc/
+    git clone --depth 1 https://github.com/fcitx/mozc/
 fi
 
 cd mozc/src/
-git fetch --all
+git fetch --all --prune --filter=tree:0
 git checkout origin/fcitx
 git submodule update --init
 


### PR DESCRIPTION
Use the flatpak version of bazel.(update_mozc_deps)

    How to use.
    Bypass access rights to TMPDIR.
    TMPDIR=~/.tmp ./update_mozc_deps
    
    Dependency on fcitx5 is at org.fcitx.Fcitx5.
    Dependency on Qt6 is in org.kde.Sdk//6.6.

and using partial clone(shallow)
