### PR TITLE
Add external modules required for aarch64 environment to mozc-deps.yaml

### DIFF
--- a/.github/workflows/update_mozc_deps.yaml
+++ b/.github/workflows/update_mozc_deps.yaml
@@ -1,0 +1,442 @@
+name: Generate Mozc Dependencies
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        options:
+          - 'flatpak'
+          - 'flatpak-serially'
+
+jobs:
+  Mozc-Dependency-x86_64:
+    if: inputs.environment != 'flatpak' && inputs.environment != 'flatpak-serially'
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:noble
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set custom apt cache directory
+        run: |
+          mkdir -p /home/runner/.apt-cache/
+          echo 'Dir::Cache::Archives "/home/runner/.apt-cache/";' | tee /etc/apt/apt.conf.d/01custom-cache
+
+      - name: Generate initial apt cache hash
+        id: initial-cache-hash
+        run: |
+          HASH=$(find /home/runner/.apt-cache -type f -name "*.deb" -exec sha256sum {} + | sort | sha256sum | cut -d ' ' -f1)
+          echo "INITIAL_CACHE_HASH=${HASH}" >> $GITHUB_OUTPUT
+
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.apt-cache
+          key: ${{ runner.os }}-noble-apt-${{ steps.initial-cache-hash.outputs.INITIAL_CACHE_HASH }}
+
+      - name: Preparing
+        run: |
+          apt-get update
+          apt-get install -y sudo apt-utils wget unzip
+
+      - name: Non-Root User Setup for Container
+        run: |
+          sudo useradd -m -d /home/nonroot/ -s /usr/bin/bash nonroot
+          sudo chown -R nonroot:nonroot /home/nonroot
+          sudo -u nonroot whoami
+          sudo -u nonroot id
+          whoami
+          id
+
+      - name: Install Bazel
+        run: |
+          sudo wget -qO /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/7.3.2/bazel-7.3.2-linux-x86_64
+          sudo chmod a+x /usr/local/bin/bazel
+
+      - name: Install Build Dependency
+        run: |
+          # mantic, lunar, jammy
+          sudo sed 's/^.*deb-src /deb-src /' -i /etc/apt/sources.list||true
+          # noble
+          sudo sed 's/Types: deb *$/Types: deb deb-src/' -i /etc/apt/sources.list.d/ubuntu.sources||true
+          sudo apt-get update
+          sudo apt-get build-dep -y mozc
+          sudo apt-get install -y build-essential dpkg-dev make git qt6-base-dev libfcitx5-qt6-dev curl jq yq
+
+      - name: Adjust permissions after apt operations
+        run: |
+          sudo chown -R $(id -u):$(id -g) /home/runner/.apt-cache
+          sudo chmod -R 700 /home/runner/.apt-cache
+          sudo rm -f /home/runner/.apt-cache/lock /home/runner/.apt-cache/partial/*
+
+      - name: Generate final apt cache hash
+        id: final-cache-hash
+        run: |
+          HASH=$(find /home/runner/.apt-cache -type f -name "*.deb" -exec sha256sum {} + | sort | sha256sum | cut -d ' ' -f1)
+          echo "FINAL_CACHE_HASH=${HASH}" >> $GITHUB_OUTPUT
+
+      - name: Update cache if changed
+        if: steps.initial-cache-hash.outputs.INITIAL_CACHE_HASH != steps.final-cache-hash.outputs.FINAL_CACHE_HASH
+        uses: actions/cache/save@v4
+        with:
+          path: /home/runner/.apt-cache
+          key: ${{ runner.os }}-noble-apt-${{ steps.final-cache-hash.outputs.FINAL_CACHE_HASH }}
+
+      - name: Generate Mozc Dependency
+        run: |
+          # prevent timeout
+          sed -i 's|bazel clean.*|rm -rf $HOME/.cache/bazel|' update_mozc_deps
+          sudo -u nonroot cp ./update_mozc_deps ./bazel_mirror.py downloader.cfg /home/nonroot/
+          WORKSPACE=$PWD
+          cd /home/nonroot
+          sudo -u nonroot PATH=$PATH:/usr/local/bin TMPDIR=/home/nonroot/tmp/ ./update_mozc_deps
+          cp ./mozc-deps.yaml $GITHUB_WORKSPACE/deps_x86_64.yaml
+      - name: Upload deps file
+        uses: actions/upload-artifact@v4
+        with:
+          name: deps-x86_64
+          path: deps_x86_64.yaml
+
+  Mozc-Dependency-x86_64-flatpak:
+    if: inputs.environment == 'flatpak'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set custom apt cache directory
+        run: |
+          mkdir -p ${{ github.workspace }}/.apt-cache/
+          echo 'Dir::Cache::Archives "${{ github.workspace }}/.apt-cache/";' | sudo tee /etc/apt/apt.conf.d/01custom-cache
+
+      - name: Generate initial apt cache hash
+        id: initial-cache-hash
+        run: |
+          HASH=$(find ${{ github.workspace }}/.apt-cache -type f -name "*.deb" -exec sha256sum {} + | sort | sha256sum | cut -d ' ' -f1)
+          echo "INITIAL_CACHE_HASH=${HASH}" >> $GITHUB_OUTPUT
+
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.apt-cache
+          key: ${{ runner.os }}-apt-${{ steps.initial-cache-hash.outputs.INITIAL_CACHE_HASH }}
+
+      - name: Cache Flatpak
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.local/share/flatpak
+          key: ${{ runner.os }}-x86_64-flatpak-${{ hashFiles('**/org.fcitx.Fcitx5.Addon.Mozc.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-x86_64-flatpak-${{ hashFiles('**/org.fcitx.Fcitx5.Addon.Mozc.yaml') }}
+
+      - name: Preparing
+        run: |
+          cat /etc/lsb-release
+          sudo apt-get update
+          sudo apt-get install -y sudo wget apt-utils
+          sudo apt-get install -y git curl unzip jq flatpak pipx
+          pipx install yq
+
+      - name: Adjust permissions after apt operations
+        run: |
+          sudo chown -R $(id -u):$(id -g) ${{ github.workspace }}/.apt-cache
+          sudo chmod -R 700 ${{ github.workspace }}/.apt-cache
+          sudo rm -f ${{ github.workspace }}/.apt-cache/lock ${{ github.workspace }}/.apt-cache/partial/*
+
+      - name: Generate final apt cache hash
+        id: final-cache-hash
+        run: |
+          HASH=$(find ${{ github.workspace }}/.apt-cache -type f -name "*.deb" -exec sha256sum {} + | sort | sha256sum | cut -d ' ' -f1)
+          echo "FINAL_CACHE_HASH=${HASH}" >> $GITHUB_OUTPUT
+
+      - name: Update cache if changed
+        if: steps.initial-cache-hash.outputs.INITIAL_CACHE_HASH != steps.final-cache-hash.outputs.FINAL_CACHE_HASH
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.apt-cache
+          key: ${{ runner.os }}-apt-${{ steps.final-cache-hash.outputs.FINAL_CACHE_HASH }}
+
+      - name: Install Sdk and Runtime of Flatpak
+        run: |
+          flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y flathub org.fcitx.Fcitx5/x86_64/stable org.kde.Sdk/x86_64/6.6 org.freedesktop.Sdk/x86_64/23.08 org.freedesktop.Sdk.Extension.bazel/x86_64/23.08 org.freedesktop.Sdk.Extension.llvm18/x86_64/23.08
+          flatpak update -y
+
+      - name: Generate Mozc Dependency
+        run: |
+          # unset ANDROID_NDK_HOME
+          env $(printenv | grep '^ANDROID_NDK' | sed 's/=.*//;s/^/-u /') PATH=$PATH:/usr/local/bin TMPDIR=$PWD/tmp sh -c './update_mozc_deps x86_64'
+          cp ./mozc-deps.yaml $GITHUB_WORKSPACE/deps_x86_64-flatpak.yaml
+
+      - name: Upload deps file
+        uses: actions/upload-artifact@v4
+        with:
+          name: deps-x86_64-flatpak
+          path: deps_x86_64-flatpak.yaml
+
+  Mozc-Dependency-arm64-flatpak:
+    if: inputs.environment == 'flatpak' || inputs.environment != 'flatpak-serially'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set custom apt cache directory
+        run: |
+          mkdir -p ${{ github.workspace }}/.apt-cache/
+          echo 'Dir::Cache::Archives "${{ github.workspace }}/.apt-cache/";' | sudo tee /etc/apt/apt.conf.d/01custom-cache
+
+      - name: Generate initial apt cache hash
+        id: initial-cache-hash
+        run: |
+          HASH=$(find ${{ github.workspace }}/.apt-cache -type f -name "*.deb" -exec sha256sum {} + | sort | sha256sum | cut -d ' ' -f1)
+          echo "INITIAL_CACHE_HASH=${HASH}" >> $GITHUB_OUTPUT
+
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.apt-cache
+          key: ${{ runner.os }}-apt-${{ steps.initial-cache-hash.outputs.INITIAL_CACHE_HASH }}
+
+      - name: Cache Flatpak
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.local/share/flatpak
+          key: ${{ runner.os }}-flatpak-${{ hashFiles('**/org.fcitx.Fcitx5.Addon.Mozc.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-flatpak-${{ hashFiles('**/org.fcitx.Fcitx5.Addon.Mozc.yaml') }}
+
+      - name: Preparing
+        run: |
+          cat /etc/lsb-release
+          sudo apt-get update
+          sudo apt-get install -y sudo wget apt-utils
+          sudo apt-get install -y git curl unzip jq flatpak pipx
+          pipx install yq
+
+      - name: Qemu and binfmt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static binfmt-support
+          sudo systemctl restart systemd-binfmt.service
+          systemctl status systemd-binfmt.service
+          sudo update-binfmts --enable qemu-aarch64
+
+      - name: Adjust permissions after apt operations
+        run: |
+          sudo chown -R $(id -u):$(id -g) ${{ github.workspace }}/.apt-cache
+          sudo chmod -R 700 ${{ github.workspace }}/.apt-cache
+          sudo rm -f ${{ github.workspace }}/.apt-cache/lock ${{ github.workspace }}/.apt-cache/partial/*
+
+      - name: Generate final apt cache hash
+        id: final-cache-hash
+        run: |
+          HASH=$(find ${{ github.workspace }}/.apt-cache -type f -name "*.deb" -exec sha256sum {} + | sort | sha256sum | cut -d ' ' -f1)
+          echo "FINAL_CACHE_HASH=${HASH}" >> $GITHUB_OUTPUT
+
+      - name: Update cache if changed
+        if: steps.initial-cache-hash.outputs.INITIAL_CACHE_HASH != steps.final-cache-hash.outputs.FINAL_CACHE_HASH
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.apt-cache
+          key: ${{ runner.os }}-apt-${{ steps.final-cache-hash.outputs.FINAL_CACHE_HASH }}
+
+      - name: Install Sdk and Runtime of Flatpak
+        run: |
+          flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y flathub org.fcitx.Fcitx5/aarch64/stable org.kde.Sdk/aarch64/6.6 org.freedesktop.Sdk/aarch64/23.08 org.freedesktop.Sdk.Extension.bazel/aarch64/23.08 org.freedesktop.Sdk.Extension.llvm18/aarch64/23.08
+          flatpak update -y
+
+      - name: Generate Mozc Dependency
+        run: |
+          # unset ANDROID_NDK_HOME
+          env $(printenv | grep '^ANDROID_NDK' | sed 's/=.*//;s/^/-u /') PATH=$PATH:/usr/local/bin TMPDIR=$PWD/tmp sh -c './update_mozc_deps aarch64'
+          cp ./mozc-deps.yaml $GITHUB_WORKSPACE/deps_arm64-flatpak.yaml
+
+      - name: Upload deps file
+        uses: actions/upload-artifact@v4
+        with:
+          name: deps-arm64-flatpak
+          path: deps_arm64-flatpak.yaml
+
+  Mozc-Dependency-flatpak:
+    if: inputs.environment == 'flatpak-serially'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set custom apt cache directory
+        run: |
+          mkdir -p ${{ github.workspace }}/.apt-cache/
+          echo 'Dir::Cache::Archives "${{ github.workspace }}/.apt-cache/";' | sudo tee /etc/apt/apt.conf.d/01custom-cache
+
+      - name: Generate initial apt cache hash
+        id: initial-cache-hash
+        run: |
+          HASH=$(find ${{ github.workspace }}/.apt-cache -type f -name "*.deb" -exec sha256sum {} + | sort | sha256sum | cut -d ' ' -f1)
+          echo "INITIAL_CACHE_HASH=${HASH}" >> $GITHUB_OUTPUT
+
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.apt-cache
+          key: ${{ runner.os }}-apt-${{ steps.initial-cache-hash.outputs.INITIAL_CACHE_HASH }}
+
+      - name: Cache Flatpak
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.local/share/flatpak
+          key: ${{ runner.os }}-multi_arch-flatpak-${{ hashFiles('**/org.fcitx.Fcitx5.Addon.Mozc.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-multi_arch-flatpak-${{ hashFiles('**/org.fcitx.Fcitx5.Addon.Mozc.yaml') }}
+
+      - name: Preparing
+        run: |
+          cat /etc/lsb-release
+          sudo apt-get update
+          sudo apt-get install -y sudo wget apt-utils
+          sudo apt-get install -y git curl unzip jq flatpak pipx
+          pipx install yq
+
+      - name: Qemu and binfmt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static binfmt-support
+          sudo systemctl restart systemd-binfmt.service
+          systemctl status systemd-binfmt.service
+          sudo update-binfmts --enable qemu-aarch64
+
+      - name: Adjust permissions after apt operations
+        run: |
+          sudo chown -R $(id -u):$(id -g) ${{ github.workspace }}/.apt-cache
+          sudo chmod -R 700 ${{ github.workspace }}/.apt-cache
+          sudo rm -f ${{ github.workspace }}/.apt-cache/lock ${{ github.workspace }}/.apt-cache/partial/*
+
+      - name: Generate final apt cache hash
+        id: final-cache-hash
+        run: |
+          HASH=$(find ${{ github.workspace }}/.apt-cache -type f -name "*.deb" -exec sha256sum {} + | sort | sha256sum | cut -d ' ' -f1)
+          echo "FINAL_CACHE_HASH=${HASH}" >> $GITHUB_OUTPUT
+
+      - name: Update cache if changed
+        if: steps.initial-cache-hash.outputs.INITIAL_CACHE_HASH != steps.final-cache-hash.outputs.FINAL_CACHE_HASH
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.apt-cache
+          key: ${{ runner.os }}-apt-${{ steps.final-cache-hash.outputs.FINAL_CACHE_HASH }}
+
+      - name: Install Sdk and Runtime of Flatpak(x86_64)
+        run: |
+          flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y flathub org.fcitx.Fcitx5/x86_64/stable org.kde.Sdk/x86_64/6.6 org.freedesktop.Sdk/x86_64/23.08 org.freedesktop.Sdk.Extension.bazel/x86_64/23.08 org.freedesktop.Sdk.Extension.llvm18/x86_64/23.08
+          flatpak update -y
+
+      - name: Install Sdk and Runtime of Flatpak(aarch64)
+        run: |
+          flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y flathub org.fcitx.Fcitx5/aarch64/stable org.kde.Sdk/aarch64/6.6 org.freedesktop.Sdk/aarch64/23.08 org.freedesktop.Sdk.Extension.bazel/aarch64/23.08 org.freedesktop.Sdk.Extension.llvm18/aarch64/23.08
+          flatpak update -y
+
+      - name: Generate Mozc Dependency
+        run: |
+          # unset ANDROID_NDK_HOME
+          env $(printenv | grep '^ANDROID_NDK' | sed 's/=.*//;s/^/-u /') PATH=$PATH:/usr/local/bin TMPDIR=$PWD/tmp sh -c './update_mozc_deps flatpak'
+          cp ./mozc-deps.yaml $GITHUB_WORKSPACE/deps-flatpak.yaml
+
+      - name: Upload deps file
+        uses: actions/upload-artifact@v4
+        with:
+          name: deps-flatpak
+          path: deps-flatpak.yaml
+
+  combine-deps:
+    needs: [Mozc-Dependency-x86_64, Mozc-Dependency-x86_64-flatpak, Mozc-Dependency-arm64-flatpak, Mozc-Dependency-flatpak]
+    if: |
+      !failure() &&
+      (needs.Mozc-Dependency-x86_64.result == 'success' ||
+       needs.Mozc-Dependency-x86_64-flatpak.result == 'success' ||
+       needs.Mozc-Dependency-arm64-flatpak.result == 'success' ||
+       needs.Mozc-Dependency-flatpak.result == 'success')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get Branch Name
+        run: |
+          if [ ${{ github.event_name }} == 'pull_request' ]
+          then
+            echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
+          else
+            echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          fi
+
+      - name: Chek Branch Name
+        run: echo "The branch name is ${{ env.BRANCH_NAME }}"
+
+      - name: Set custom apt cache directory
+        run: |
+          mkdir -p ${{ github.workspace }}/.apt-cache/
+          echo 'Dir::Cache::Archives "${{ github.workspace }}/.apt-cache/";' | sudo tee /etc/apt/apt.conf.d/01custom-cache
+
+      - name: Generate initial apt cache hash
+        id: initial-cache-hash
+        run: |
+          HASH=$(find ${{ github.workspace }}/.apt-cache -type f -name "*.deb" -exec sha256sum {} + | sort | sha256sum | cut -d ' ' -f1)
+          echo "INITIAL_CACHE_HASH=${HASH}" >> $GITHUB_OUTPUT
+
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.apt-cache
+          key: ${{ runner.os }}-apt-${{ steps.initial-cache-hash.outputs.INITIAL_CACHE_HASH }}
+
+      - name: Install jq and yq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq pipx
+          pipx install yq
+
+      - name: Adjust permissions after apt operations
+        run: |
+          sudo chown -R $(id -u):$(id -g) ${{ github.workspace }}/.apt-cache
+          sudo chmod -R 700 ${{ github.workspace }}/.apt-cache
+          sudo rm -f ${{ github.workspace }}/.apt-cache/lock ${{ github.workspace }}/.apt-cache/partial/*
+
+      - name: Generate final apt cache hash
+        id: final-cache-hash
+        run: |
+          HASH=$(find ${{ github.workspace }}/.apt-cache -type f -name "*.deb" -exec sha256sum {} + | sort | sha256sum | cut -d ' ' -f1)
+          echo "FINAL_CACHE_HASH=${HASH}" >> $GITHUB_OUTPUT
+
+      - name: Update cache if changed
+        if: steps.initial-cache-hash.outputs.INITIAL_CACHE_HASH != steps.final-cache-hash.outputs.FINAL_CACHE_HASH
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.apt-cache
+          key: ${{ runner.os }}-apt-${{ steps.final-cache-hash.outputs.FINAL_CACHE_HASH }}
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: deps-*
+          path: deps
+
+      - name: Combine and Deduplicated
+        run: |
+          set -e
+          rm -f combined_deps.yaml
+          cat deps/deps-*/deps_*.yaml |tee -a combined_deps.yaml
+          yq -y 'unique_by(.url)|sort_by(.url)' combined_deps.yaml |tee mozc-deps.yaml
+
+      - name: Commit and Push Changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add mozc-deps.yaml
+           ./update_mozc_zip_code_patch
+          git diff --exit-code || {
+            git commit -m "Update mozc-deps.yaml and zip-code.patch with latest dependencies" -a
+            git push origin ${{ env.BRANCH_NAME }}
+          }

--- a/mozc-deps.yaml
+++ b/mozc-deps.yaml
@@ -67,9 +67,17 @@
   dest: bazel-deps
   sha256: bb01097c7c7a1407f8ad49a1a0b1960655cf823c26ad2782d0b7d15b323838e2
 - type: file
+  url: https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.11.9+20240415-aarch64-unknown-linux-gnu-install_only.tar.gz
+  dest: bazel-deps
+  sha256: b3a7199ac2615d75fb906e5ba556432efcf24baf8651fc70370d9f052d4069ee
+  only-arches:
+    - aarch64
+- type: file
   url: https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.11.9+20240415-x86_64-unknown-linux-gnu-install_only.tar.gz
   dest: bazel-deps
   sha256: 78b1c16a9fd032997ba92a60f46a64f795cd18ff335659dfdf6096df277b24d5
+  only-arches:
+    - x86_64
 - type: file
   url: https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
   dest: bazel-deps

--- a/mozc-deps.yaml
+++ b/mozc-deps.yaml
@@ -1,11 +1,7 @@
 - type: file
-  url: https://github.com/JetBrains/kotlin/releases/download/v1.9.22/kotlin-compiler-1.9.22.zip
+  url: https://github.com/bazel-contrib/bazel_features/releases/download/v1.11.0/bazel_features-v1.11.0.tar.gz
   dest: bazel-deps
-  sha256: 88b39213506532c816ff56348c07bbeefe0c8d18943bffbad11063cf97cac3e6
-- type: file
-  url: https://github.com/bazel-contrib/bazel_features/releases/download/v1.13.0/bazel_features-v1.13.0.tar.gz
-  dest: bazel-deps
-  sha256: 5d7e4eb0bb17aee392143cd667b67d9044c270a9345776a5e5a3cccbc44aa4b3
+  sha256: 2cd9e57d4c38675d321731d65c15258f3a66438ad531ae09cb8bb14217dc8572
 - type: file
   url: https://github.com/bazelbuild/apple_support/releases/download/1.16.0/apple_support.1.16.0.tar.gz
   dest: bazel-deps
@@ -19,10 +15,6 @@
   dest: bazel-deps
   sha256: 218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee
 - type: file
-  url: https://github.com/bazelbuild/rules_android/releases/download/v0.5.1/rules_android-v0.5.1.tar.gz
-  dest: bazel-deps
-  sha256: b1599e4604c1594a1b0754184c5e50f895a68f444d1a5a82b688b2370d990ba0
-- type: file
   url: https://github.com/bazelbuild/rules_android_ndk/releases/download/v0.1.2/rules_android_ndk-v0.1.2.tar.gz
   dest: bazel-deps
   sha256: 65aedff0cd728bee394f6fb8e65ba39c4c5efb11b29b766356922d4a74c623f5
@@ -35,17 +27,9 @@
   dest: bazel-deps
   sha256: 2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf
 - type: file
-  url: https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip
-  dest: bazel-deps
-  sha256: 33acc4ae0f70502db4b893c9fc1dd7a9bf998c23e7ff2c4517741d4049a976f8
-- type: file
   url: https://github.com/bazelbuild/rules_java/releases/download/7.9.0/rules_java-7.9.0.tar.gz
   dest: bazel-deps
   sha256: 41131de4417de70b9597e6ebd515168ed0ba843a325dc54a81b92d7af9a7b3ea
-- type: file
-  url: https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.5/rules_kotlin-v1.9.5.tar.gz
-  dest: bazel-deps
-  sha256: 34e8c0351764b71d78f76c8746e98063979ce08dcf1a91666f3f3bc2949a533d
 - type: file
   url: https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz
   dest: bazel-deps
@@ -55,9 +39,9 @@
   dest: bazel-deps
   sha256: 8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2
 - type: file
-  url: https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz
+  url: https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc1/rules_proto-6.0.0-rc1.tar.gz
   dest: bazel-deps
-  sha256: 303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d
+  sha256: 904a8097fae42a690c8e08d805210e40cccb069f5f9a0f6727cf4faa7bed2c9c
 - type: file
   url: https://github.com/bazelbuild/rules_python/releases/download/0.34.0/rules_python-0.34.0.tar.gz
   dest: bazel-deps
@@ -85,8 +69,8 @@
 - type: file
   url: https://www.post.japanpost.jp/zipcode/dl/jigyosyo/zip/jigyosyo.zip
   dest: bazel-deps
-  sha256: 1ef5d43b5e5bf059117a2570fe95e0a9e3cf8a27f3e3882da283ad18460d2264
+  sha256: 5d52511ce6613fcc0c5b24ac59b463e927cff76ac466c2ae07a511a64bb5913f
 - type: file
   url: https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip
   dest: bazel-deps
-  sha256: 85f13da74bf178ecb18083ec6d31e63bc4395c7817c3bb3587c7e86707609d2a
+  sha256: e5a32c0199ebc890ea5c48c06fd817a168b26d68ce1c3a86ba0ae1cdf6c2d1c4

--- a/update_mozc_deps
+++ b/update_mozc_deps
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cleanup() {
-    pkill -P $$
+    pkill -P $$ || true
 }
 
 trap cleanup EXIT
@@ -44,11 +44,73 @@ PROXY_PID=$!
 popd
 [[ -z $PROXY_PID ]] && exit 1
 
-bazel clean --expunge
-
 BUILD_TARGET="unix/fcitx5:fcitx5-mozc.so server:mozc_server gui/tool:mozc_tool"
-echo bazel build --nobuild --experimental_downloader_config="$SCRIPT_DIRECTORY/downloader.cfg" --registry=file://$BASE/bcr --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux --config release_build $BUILD_TARGET
-bazel build --nobuild --experimental_downloader_config="$SCRIPT_DIRECTORY/downloader.cfg" --registry=file://$BASE/bcr --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux --config release_build $BUILD_TARGET
+
+build_native() {
+    echo bazel build --nobuild --experimental_downloader_config="$SCRIPT_DIRECTORY/downloader.cfg" --registry=file://$BASE/bcr --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux --config release_build $BUILD_TARGET
+    bazel clean --expunge
+    bazel build --nobuild --experimental_downloader_config="$SCRIPT_DIRECTORY/downloader.cfg" --registry=file://$BASE/bcr --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux --config release_build $BUILD_TARGET
+}
+
+build_x86_64() {
+    # x86_64 flatpak
+    flatpak run --arch=x86_64 --command=sh \
+        --env=BASE="$BASE" \
+        --env=TMPDIR="$TMPDIR" \
+        --env=PKG_CONFIG_PATH=/app/lib/pkgconfig \
+        --env=SCRIPT_DIRECTORY="$SCRIPT_DIRECTORY" \
+        --env=_MOZC_BAZEL_CACHE="$_MOZC_BAZEL_CACHE" \
+        --env=BUILD_TARGET="$BUILD_TARGET" \
+        --share=network --filesystem=xdg-cache \
+        --filesystem="$SCRIPT_DIRECTORY" --filesystem="$TMPDIR" \
+        --runtime=org.kde.Sdk/x86_64/6.6 org.fcitx.Fcitx5/x86_64/stable \
+        -c "\
+            PATH=$PATH:/usr/lib/sdk/bazel/bin:/usr/lib/sdk/llvm18/bin ; \
+            CC=clang ; CXX=clang++ ; clang --version ; bazel --version ;\
+            bazel clean --expunge ; \
+            bazel build --nobuild --experimental_downloader_config="\$SCRIPT_DIRECTORY/downloader.cfg" \
+            --registry=file://\$BASE/bcr \
+            --repository_cache="\$_MOZC_BAZEL_CACHE" \
+            --config oss_linux --config release_build \${BUILD_TARGET}
+        "
+}
+
+build_aarch64() {
+    # aarch64 emulation flatpak with qemu-user-static-binfmt
+    flatpak run --arch=aarch64 --command=sh \
+        --env=BASE="$BASE" \
+        --env=TMPDIR="$TMPDIR" \
+        --env=PKG_CONFIG_PATH=/app/lib/pkgconfig \
+        --env=SCRIPT_DIRECTORY="$SCRIPT_DIRECTORY" \
+        --env=_MOZC_BAZEL_CACHE="$_MOZC_BAZEL_CACHE" \
+        --env=BUILD_TARGET="$BUILD_TARGET" \
+        --share=network --filesystem=xdg-cache \
+        --filesystem="$SCRIPT_DIRECTORY" --filesystem="$TMPDIR" \
+        --runtime=org.kde.Sdk/aarch64/6.6 org.fcitx.Fcitx5/aarch64/stable \
+        -c "\
+            PATH=$PATH:/usr/lib/sdk/bazel/bin:/usr/lib/sdk/llvm18/bin ; \
+            CC=clang ; CXX=clang++ ; clang --version ; bazel --version ;\
+            bazel clean --expunge ; \
+            bazel build --nobuild --experimental_downloader_config="\$SCRIPT_DIRECTORY/downloader.cfg" \
+            --registry=file://\$BASE/bcr \
+            --repository_cache="\$_MOZC_BAZEL_CACHE" \
+            --config oss_linux --config release_build \${BUILD_TARGET}
+        "
+}
+
+if [ "$1" = "aarch64" ]; then
+    build_aarch64
+elif [ "$1" = "x86_64" ]; then
+    build_x86_64
+elif [ "$1" = "multi_arch" ]; then
+    build_native
+    build_aarch64
+elif [ "$1" = "flatpak" ]; then
+    build_x86_64
+    build_aarch64
+else
+    build_native
+fi
 
 kill $PROXY_PID
 
@@ -66,6 +128,19 @@ for f in `find -type f` ; do
 done > $SCRIPT_DIRECTORY/mozc-deps.yaml
 popd
 
+# add only-arches for cpython x86_64 and aarch64
+yq -i -y '.[]|=
+  .url as $url |
+  if ($url | split("/")[-1] | contains("cpython") and contains("x86_64")) then
+    . += {"only-arches": ["x86_64"]}
+  elif ($url | split("/")[-1] | contains("cpython") and contains("aarch64")) then
+    . += {"only-arches": ["aarch64"]}
+  else
+    .
+  end
+' "$SCRIPT_DIRECTORY/mozc-deps.yaml"
+
 yq -y -i 'sort_by(.url)' "$SCRIPT_DIRECTORY/mozc-deps.yaml"
 
 rm -rf "$BASE"
+exit 0

--- a/zip-code.patch
+++ b/zip-code.patch
@@ -8,8 +8,8 @@ index 2675e04..7336fbe 100644
  # SHA256 values should be specified.
 -SHA256_ZIP_CODE_KEN_ALL = None
 -SHA256_ZIP_CODE_JIGYOSYO = None
-+SHA256_ZIP_CODE_KEN_ALL = "85f13da74bf178ecb18083ec6d31e63bc4395c7817c3bb3587c7e86707609d2a"
-+SHA256_ZIP_CODE_JIGYOSYO = "1ef5d43b5e5bf059117a2570fe95e0a9e3cf8a27f3e3882da283ad18460d2264"
++SHA256_ZIP_CODE_KEN_ALL = "e5a32c0199ebc890ea5c48c06fd817a168b26d68ce1c3a86ba0ae1cdf6c2d1c4"
++SHA256_ZIP_CODE_JIGYOSYO = "5d52511ce6613fcc0c5b24ac59b463e927cff76ac466c2ae07a511a64bb5913f"
 diff --git a/src/MODULE.bazel b/src/MODULE.bazel
 index 577917e..ac6f1c9 100644
 --- a/src/MODULE.bazel
@@ -19,7 +19,7 @@ index 577917e..ac6f1c9 100644
  # SHA256 as of 2024-08-14
  # SHA256_ZIP_CODE_KEN_ALL = "d2d177ef64b9459a618d8aaa96b6c5f081cb3f37f6e9c00ba912001e66b81f3e"
 -SHA256_ZIP_CODE_KEN_ALL = None
-+SHA256_ZIP_CODE_KEN_ALL = "85f13da74bf178ecb18083ec6d31e63bc4395c7817c3bb3587c7e86707609d2a"
++SHA256_ZIP_CODE_KEN_ALL = "e5a32c0199ebc890ea5c48c06fd817a168b26d68ce1c3a86ba0ae1cdf6c2d1c4"
  http_archive(
      name = "zip_code_ken_all",
      build_file_content = "exports_files([\"KEN_ALL.CSV\"])",
@@ -28,7 +28,7 @@ index 577917e..ac6f1c9 100644
  # SHA256 as of 2024-08-14
  # SHA256_ZIP_CODE_JIGYOSYO="ab6fd92df35e63c4566d29f70456da1603d8178ce3fec073f7c27b28d0af2e10"
 -SHA256_ZIP_CODE_JIGYOSYO = None
-+SHA256_ZIP_CODE_JIGYOSYO = "1ef5d43b5e5bf059117a2570fe95e0a9e3cf8a27f3e3882da283ad18460d2264"
++SHA256_ZIP_CODE_JIGYOSYO = "5d52511ce6613fcc0c5b24ac59b463e927cff76ac466c2ae07a511a64bb5913f"
  http_archive(
      name = "zip_code_jigyosyo",
      build_file_content = "exports_files([\"JIGYOSYO.CSV\"])",


### PR DESCRIPTION
In #28, CPython URLs are compiled in a separate file as they are not expected to change frequently.

In this approach, while the aarch64 version of CPython URL needs to be hardcoded, it is added directly to mozc-deps.yaml.

If a cross-compilation environment were available, we could potentially run bazel build for both x86_64 and aarch64, triggering downloads for both architectures. This might eliminate the need for hardcoding.

```
 I added the URL for the aarch64 version of CPython by hardcoding it within update_mozc_deps and downloading it through a proxy, then adding it to mozc-deps.yaml.
Additionally, I implemented a process to add the 'only-arches' item if the URL contains 'x86_64' or 'aarch64'.
```

PS.
We have switched to updating using qemu and flatpak.
Please check the comment below.