### PR TITLE
Automation test fix

### DIFF
--- a/.github/workflows/moze-update.yml
+++ b/.github/workflows/moze-update.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: archlinux:latest
-      options: --privileged
+      options: --init --privileged
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/moze-update.yml
+++ b/.github/workflows/moze-update.yml
@@ -14,7 +14,9 @@ jobs:
   update:
     name: Build and test
     runs-on: ubuntu-latest
-    container: archlinux:latest
+    container:
+      image: archlinux:latest
+      options: --privileged
     strategy:
       fail-fast: false
     steps:
@@ -23,9 +25,25 @@ jobs:
           useradd -m builduser
       - name: Install dependencies
         run: |
-          pacman -Syu --noconfirm base-devel clang cmake ninja extra-cmake-modules fmt libuv boost git qt6-base qt6-wayland libxkbcommon qt6-webengine flatpak procps-ng python3 yq wget git qemu-user-static-binfmt
-          /usr/lib/systemd/systemd-binfmt
+          pacman -Syu --needed --noconfirm base-devel clang cmake ninja extra-cmake-modules fmt libuv boost git qt6-base qt6-wayland libxkbcommon qt6-webengine flatpak procps-ng python3 yq wget git qemu-user-static-binfmt #aarch64-linux-gnu-glibc
           flatpak install -y --system org.freedesktop.Sdk/aarch64/23.08
+      - name: Qemu and binfmt
+        run: |
+          if [ ! -d /proc/sys/fs/binfmt_misc ]; then
+            if ! /sbin/modprobe binfmt_misc ; then
+              exit 1
+            fi
+          fi
+          if [ ! -f /proc/sys/fs/binfmt_misc/register ]; then
+            if ! mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc ; then
+              exit 1
+            fi
+          fi
+          if [ -w "/proc/sys/fs/binfmt_misc/register" ]; then
+            sudo sh -c 'echo -1 > /proc/sys/fs/binfmt_misc/qemu-aarch64' || true
+            cat /usr/lib/binfmt.d/qemu-aarch64-static.conf|sudo tee /proc/sys/fs/binfmt_misc/register || true
+          fi
+
       - uses: actions/checkout@v4
         with:
           repository: fcitx/fcitx5
@@ -51,6 +69,11 @@ jobs:
         run: |
           cd flatpak-fcitx5
           chown -R builduser:builduser .
-          sudo -u builduser ./update_mozc_deps
-          git diff
+          sudo -u builduser \
+            LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib64 \
+            QEMU_LD_PREFIX=/usr/aarch64-linux-gnu \
+            TMPDIR=$PWD/tmp \
+            ./update_mozc_deps
+          sudo -u builduser ./update_mozc_zip_code_patch
           chown -R root:root .
+          git diff || true

--- a/.github/workflows/moze-update.yml
+++ b/.github/workflows/moze-update.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 13 * * *"
+
+jobs:
+  update:
+    name: Build and test
+    runs-on: ubuntu-latest
+    container: archlinux:latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Setup User
+        run: |
+          useradd -m builduser
+      - name: Install dependencies
+        run: |
+          pacman -Syu --noconfirm base-devel clang cmake ninja extra-cmake-modules fmt libuv boost git qt6-base qt6-wayland libxkbcommon qt6-webengine flatpak procps-ng python3 yq wget git qemu-user-static-binfmt
+          /usr/lib/systemd/systemd-binfmt
+          flatpak install -y --system org.freedesktop.Sdk/aarch64/23.08
+      - uses: actions/checkout@v4
+        with:
+          repository: fcitx/fcitx5
+          path: fcitx5
+      - name: Cache fcitx5 data files
+        uses: actions/cache@v4
+        with:
+          path: 'fcitx5/**/*.tar.*'
+          key: ${{ runner.os }}-${{ hashFiles('fcitx5/src/modules/spell/CMakeLists.txt') }}
+      - name: Build and Install fcitx5
+        uses: fcitx/github-actions@cmake
+        with:
+          path: fcitx5
+          cmake-option: >-
+            -DENABLE_KEYBOARD=Off -DENABLE_X11=Off -DENABLE_WAYLAND=Off -DENABLE_ENCHANT=Off
+            -DENABLE_DBUS=Off -DENABLE_SERVER=Off -DENABLE_EMOJI=Off -DUSE_SYSTEMD=Off
+          install-prefix: /usr
+      - uses: actions/checkout@v4
+        with:
+          path: flatpak-fcitx5
+          submodules: true
+      - name: Update
+        run: |
+          cd flatpak-fcitx5
+          chown -R builduser:builduser .
+          sudo -u builduser ./update_mozc_deps
+          git diff
+          chown -R root:root .

--- a/update_mozc_deps
+++ b/update_mozc_deps
@@ -28,8 +28,8 @@ check_and_download_bazel() {
 }
 
 run_bazel() {
-    #echo $1 clean --expunge
-    #$1 clean --expunge
+    echo $1 clean --expunge
+    $1 clean --expunge
     echo $1 build --nobuild --experimental_downloader_config="$SCRIPT_DIRECTORY/downloader.cfg" --registry=file://$BASE/bcr --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux --config release_build $2
     $1 build --nobuild --experimental_downloader_config="$SCRIPT_DIRECTORY/downloader.cfg" --registry=file://$BASE/bcr --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux --config release_build $2
 }

--- a/update_mozc_deps
+++ b/update_mozc_deps
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cleanup() {
-    pkill -P $$
+    pkill -P $$ || true
 }
 
 check_bazel_binary() {
@@ -28,8 +28,8 @@ check_and_download_bazel() {
 }
 
 run_bazel() {
-    echo $1 clean --expunge
-    # $1 clean --expunge
+    #echo $1 clean --expunge
+    #$1 clean --expunge
     echo $1 build --nobuild --experimental_downloader_config="$SCRIPT_DIRECTORY/downloader.cfg" --registry=file://$BASE/bcr --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux --config release_build $2
     $1 build --nobuild --experimental_downloader_config="$SCRIPT_DIRECTORY/downloader.cfg" --registry=file://$BASE/bcr --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux --config release_build $2
 }
@@ -87,10 +87,10 @@ cd mozc/src/
 BUILD_TARGET_SERVER="server:mozc_server"
 BUILD_TARGET="unix/fcitx5:fcitx5-mozc.so ${BUILD_TARGET_SERVER} gui/tool:mozc_tool"
 
-run_bazel "$BASE/bazel-x86_64" $BUILD_TARGET
+run_bazel "$BASE/bazel-x86_64" "$BUILD_TARGET"
 # Only run aarch64 against server target, as with flatpak we have no external dependencies
 # TODO: apply only tag for deps
-run_bazel "flatpak run --filesystem=$PWD --filesystem=home --share=network --command=$BASE/bazel-arm64 org.freedesktop.Sdk/aarch64/23.08" $BUILD_TARGET_SERVER
+run_bazel "flatpak run --arch=aarch64 --filesystem=$SCRIPT_DIRECTORY --filesystem=home --share=network --filesystem=xdg-cache --command=$BASE/bazel-arm64 org.freedesktop.Sdk/aarch64/23.08" "$BUILD_TARGET_SERVER"
 
 kill $PROXY_PID
 

--- a/update_mozc_deps
+++ b/update_mozc_deps
@@ -14,20 +14,22 @@ check_and_download_bazel() {
     local BAZEL_URL=`yq -r '.sources[].url | select(contains("'$1'"))' "$SCRIPT_DIRECTORY/modules/bazel.yaml"`
     FILENAME="$(basename "$BAZEL_URL")"
     if [ -f "bazel-$1" ]; then
+        chmod +x bazel-$1
         if check_bazel_binary $1 ; then
             return 0
         else
             rm -f "bazel-$1"
         fi
     fi
-    wget -O bazel-$1 ${BAZEL_URL}
+    wget -nv -O bazel-$1 ${BAZEL_URL}
+    chmod +x bazel-$1
     check_bazel_binary $1
     return $?
 }
 
 run_bazel() {
     echo $1 clean --expunge
-    $1 clean --expunge
+    # $1 clean --expunge
     echo $1 build --nobuild --experimental_downloader_config="$SCRIPT_DIRECTORY/downloader.cfg" --registry=file://$BASE/bcr --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux --config release_build $2
     $1 build --nobuild --experimental_downloader_config="$SCRIPT_DIRECTORY/downloader.cfg" --registry=file://$BASE/bcr --repository_cache="$_MOZC_BAZEL_CACHE" --config oss_linux --config release_build $2
 }
@@ -88,7 +90,7 @@ BUILD_TARGET="unix/fcitx5:fcitx5-mozc.so ${BUILD_TARGET_SERVER} gui/tool:mozc_to
 run_bazel "$BASE/bazel-x86_64" $BUILD_TARGET
 # Only run aarch64 against server target, as with flatpak we have no external dependencies
 # TODO: apply only tag for deps
-run_bazel "flatpak run --filesystem=home --share=network --command=$BASE/bazel-arm64 org.freedesktop.Sdk/aarch64/23.08" $BUILD_TARGET_SERVER
+run_bazel "flatpak run --filesystem=$PWD --filesystem=home --share=network --command=$BASE/bazel-arm64 org.freedesktop.Sdk/aarch64/23.08" $BUILD_TARGET_SERVER
 
 kill $PROXY_PID
 


### PR DESCRIPTION
    Workflow and Script Modifications
    
    Workflows:
      Added --privileged option to the container.
      Set QEMU_LD_PREFIX and LD_LIBRARY_PATH for aarch64.
      Manually configured QEMU binfmt for aarch64 as systemd is not running.
      Commented out bazel clean --expunge due to timeout issues.
    
    update_mozc_deps:
      Modified the part that calls the run_bazel function for arm64
      Slightly modified the pkill command in cleanup to prevent workflow stoppage.


    To avoid timeouts in bazel clean or bazel build

      add the --init option to the container startup options.